### PR TITLE
Require root to run

### DIFF
--- a/gnomeforpi-install
+++ b/gnomeforpi-install
@@ -1,4 +1,10 @@
-#!/usr/bin/env bash
+#!/usr/bin/env bash -e
+
+if [ "${UID}" != "0" ]; then
+  echo "You must be root to run this script"
+  exit 1
+fi
+
 echo "Starting script..."
 
 echo "Updating Repositories"


### PR DESCRIPTION
This also includes a `-e` at the top to ensure that the script dies when anything in the chain fails.  This prevents partial completion appearing as if it's 100% complete.